### PR TITLE
Fixed building of retry threshold decorator.

### DIFF
--- a/fab/Worker/RetryThresholdDecorator/Builder.php
+++ b/fab/Worker/RetryThresholdDecorator/Builder.php
@@ -17,7 +17,7 @@ class Builder implements BuilderInterface
 
     public function build(): DecoratorInterface
     {
-        $decorator = $this->getWorkerRetriedThresholdDecoratorFactory()
+        $decorator = $this->getWorkerRetryThresholdDecoratorFactory()
             ->create();
 
         $decorator->setApiV1RDBMSConnectionService($this->getApiV1RDBMSConnectionService());


### PR DESCRIPTION
Looks like you missed a file when in https://github.com/neighborhoods/KojoWorkerDecoratorComponent/pull/3.
Were you able to use the Retry Threshold Decorator on version 1.0.2?